### PR TITLE
Triton backend API version issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,14 +87,13 @@ FetchContent_Declare(
   GIT_TAG ${TRITON_BACKEND_REPO_TAG}
   GIT_SHALLOW ON
 )
-#FetchContent_Declare(
-#  repo-ft
-#  GIT_REPOSITORY https://github.com/NVIDIA/FasterTransformer.git
-#  GIT_TAG main
-#  GIT_SHALLOW ON
-#)
-#FetchContent_MakeAvailable(repo-common repo-core repo-backend repo-ft)
-FetchContent_MakeAvailable(repo-common repo-core repo-backend)
+FetchContent_Declare(
+  repo-ft
+  GIT_REPOSITORY https://github.com/NVIDIA/FasterTransformer.git
+  GIT_TAG main
+  GIT_SHALLOW ON
+)
+FetchContent_MakeAvailable(repo-common repo-core repo-backend repo-ft)
 
 #
 # CUDA
@@ -141,18 +140,14 @@ target_include_directories(
   ${TRITON_PYTORCH_INCLUDE_PATHS}
   ${Python3_INCLUDE_DIRS}
   ${MPI_INCLUDE_PATH}
-  #${repo-ft_SOURCE_DIR}
-  ${PROJECT_SOURCE_DIR}/FasterTransformer
+  ${repo-ft_SOURCE_DIR}
   )
-
-set(FasterTransformer_Libraries ${PROJECT_SOURCE_DIR}/FasterTransformer/build/lib)
 
 target_link_directories(
   triton-transformer-backend
   PRIVATE
   ${CUDA_PATH}/lib64
   ${MPI_Libraries}
-  ${FasterTransformer_Libraries}
   )
 
 target_compile_features(triton-transformer-backend PRIVATE cxx_std_14)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,9 +36,9 @@ option(TRITON_ENABLE_STATS "Include statistics collections in backend" ON)
 set(TRITON_PYTORCH_INCLUDE_PATHS "" CACHE PATH "Paths to Torch includes")
 set(TRITON_PYTORCH_LIB_PATHS "" CACHE PATH "Paths to Torch libraries")
 
-set(TRITON_BACKEND_REPO_TAG "r21.02" CACHE STRING "Tag for triton-inference-server/backend repo")
-set(TRITON_CORE_REPO_TAG "r21.02" CACHE STRING "Tag for triton-inference-server/core repo")
-set(TRITON_COMMON_REPO_TAG "r21.02" CACHE STRING "Tag for triton-inference-server/common repo")
+set(TRITON_BACKEND_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/backend repo")
+set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/core repo")
+set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/common repo")
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,13 +87,14 @@ FetchContent_Declare(
   GIT_TAG ${TRITON_BACKEND_REPO_TAG}
   GIT_SHALLOW ON
 )
-FetchContent_Declare(
-  repo-ft
-  GIT_REPOSITORY https://github.com/NVIDIA/FasterTransformer.git
-  GIT_TAG main
-  GIT_SHALLOW ON
-)
-FetchContent_MakeAvailable(repo-common repo-core repo-backend repo-ft)
+#FetchContent_Declare(
+#  repo-ft
+#  GIT_REPOSITORY https://github.com/NVIDIA/FasterTransformer.git
+#  GIT_TAG main
+#  GIT_SHALLOW ON
+#)
+#FetchContent_MakeAvailable(repo-common repo-core repo-backend repo-ft)
+FetchContent_MakeAvailable(repo-common repo-core repo-backend)
 
 #
 # CUDA
@@ -140,14 +141,18 @@ target_include_directories(
   ${TRITON_PYTORCH_INCLUDE_PATHS}
   ${Python3_INCLUDE_DIRS}
   ${MPI_INCLUDE_PATH}
-  ${repo-ft_SOURCE_DIR}
+  #${repo-ft_SOURCE_DIR}
+  ${PROJECT_SOURCE_DIR}/FasterTransformer
   )
+
+set(FasterTransformer_Libraries ${PROJECT_SOURCE_DIR}/FasterTransformer/build/lib)
 
 target_link_directories(
   triton-transformer-backend
   PRIVATE
   ${CUDA_PATH}/lib64
   ${MPI_Libraries}
+  ${FasterTransformer_Libraries}
   )
 
 target_compile_features(triton-transformer-backend PRIVATE cxx_std_14)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,9 +36,9 @@ option(TRITON_ENABLE_STATS "Include statistics collections in backend" ON)
 set(TRITON_PYTORCH_INCLUDE_PATHS "" CACHE PATH "Paths to Torch includes")
 set(TRITON_PYTORCH_LIB_PATHS "" CACHE PATH "Paths to Torch libraries")
 
-set(TRITON_BACKEND_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/backend repo")
-set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/core repo")
-set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/common repo")
+set(TRITON_BACKEND_REPO_TAG "r21.02" CACHE STRING "Tag for triton-inference-server/backend repo")
+set(TRITON_CORE_REPO_TAG "r21.02" CACHE STRING "Tag for triton-inference-server/core repo")
+set(TRITON_COMMON_REPO_TAG "r21.02" CACHE STRING "Tag for triton-inference-server/common repo")
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)


### PR DESCRIPTION
Update "CMakeList.txt" for Triton backend API version issue

`failed to load 'transformer' version 1: Unsupported: Triton TRITONBACKEND API version: 1.0 does not support 'transformer' TRITONBACKEND API version: 1.2`

