### PR TITLE
refine benchmark script

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,20 @@ The model configuration for Triton server is put in `all_models/transformer/conf
 - batch_size: max supported batch size
 - is_fuse_QKV: fusing QKV in one matrix multiplication or not. It also depends on the weights of QKV.
 
+* Benchmark on single node
+
+Run this script with different batch size, input_len, output_len, num of runs on a single node with 8 gpus, it will start the server, then start the client to get the latency and stop the server at the end.
+
+```
+# run with batch_size = 8, input_len = 512, output_len = 16, and run 10 times to get the average latency
+bash $WORKSPACE/fastertransformer_backend/tools/benchmark_single_node.sh -b 8 -i 512 -o 16 -n 10
+
+```
+
+
+
+
+
 ## How to Run multi-node on the Cluster with Enroot/Pyxis support
 
 **Warp up everything in a docker**: as described in *Prepare the ft-triton-backend docker* step.

--- a/all_models/fastertransformer/config.pbtxt
+++ b/all_models/fastertransformer/config.pbtxt
@@ -1,33 +1,8 @@
-# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions
-# are met:
-#  * Redistributions of source code must retain the above copyright
-#    notice, this list of conditions and the following disclaimer.
-#  * Redistributions in binary form must reproduce the above copyright
-#    notice, this list of conditions and the following disclaimer in the
-#    documentation and/or other materials provided with the distribution.
-#  * Neither the name of NVIDIA CORPORATION nor the names of its
-#    contributors may be used to endorse or promote products derived
-#    from this software without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
-# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
-# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 name: "fastertransformer"
 backend: "fastertransformer"
-default_model_filename: "gpt3-c-model-8gpu"
-max_batch_size: 128
+default_model_filename: "gpt3_89B"
+max_batch_size: 8
 input [
   {
     name: "INPUT_ID"
@@ -80,7 +55,7 @@ parameters {
 parameters {
   key: "layer_para_size"
   value: {
-    string_value: "2"
+    string_value: "1"
   }
 }
 parameters {
@@ -92,7 +67,7 @@ parameters {
 parameters {
   key: "max_seq_len"
   value: {
-    string_value: "32"
+    string_value: "544"
   }
 }
 parameters {
@@ -104,37 +79,37 @@ parameters {
 parameters {
   key: "head_num"
   value: {
-    string_value: "16"
+    string_value: "96"
   }
 }
 parameters {
   key: "size_per_head"
   value: {
-    string_value: "64"
+    string_value: "128"
   }
 }
 parameters {
   key: "vocab_size"
   value: {
-    string_value: "50304"
+    string_value: "51200"
   }
 }
 parameters {
   key: "decoder_layers"
   value: {
-    string_value: "24"
+    string_value: "48"
   }
 }
 parameters {
   key: "model_name"
   value: {
-    string_value: "gpt_345M"
+    string_value: "gpt3_89B"
   }
 }
 parameters {
   key: "batch_size"
   value: {
-    string_value: "128"
+    string_value: "8"
   }
 }
 parameters {
@@ -155,3 +130,4 @@ parameters {
     string_value: "1.0"
   }
 }
+

--- a/all_models/fastertransformer/config.pbtxt
+++ b/all_models/fastertransformer/config.pbtxt
@@ -1,8 +1,33 @@
+# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 name: "fastertransformer"
 backend: "fastertransformer"
-default_model_filename: "gpt3_89B"
-max_batch_size: 8
+default_model_filename: "gpt3-c-model-8gpu"
+max_batch_size: 128
 input [
   {
     name: "INPUT_ID"
@@ -55,7 +80,7 @@ parameters {
 parameters {
   key: "layer_para_size"
   value: {
-    string_value: "1"
+    string_value: "2"
   }
 }
 parameters {
@@ -67,7 +92,7 @@ parameters {
 parameters {
   key: "max_seq_len"
   value: {
-    string_value: "544"
+    string_value: "32"
   }
 }
 parameters {
@@ -79,37 +104,37 @@ parameters {
 parameters {
   key: "head_num"
   value: {
-    string_value: "96"
+    string_value: "16"
   }
 }
 parameters {
   key: "size_per_head"
   value: {
-    string_value: "128"
+    string_value: "64"
   }
 }
 parameters {
   key: "vocab_size"
   value: {
-    string_value: "51200"
+    string_value: "50304"
   }
 }
 parameters {
   key: "decoder_layers"
   value: {
-    string_value: "48"
+    string_value: "24"
   }
 }
 parameters {
   key: "model_name"
   value: {
-    string_value: "gpt3_89B"
+    string_value: "gpt_345M"
   }
 }
 parameters {
   key: "batch_size"
   value: {
-    string_value: "8"
+    string_value: "128"
   }
 }
 parameters {
@@ -130,4 +155,3 @@ parameters {
     string_value: "1.0"
   }
 }
-

--- a/tools/benchmark_single_node.sh
+++ b/tools/benchmark_single_node.sh
@@ -29,7 +29,7 @@
 MODEL_FILENAME=gpt3_89B
 BATCH_SIZE=16
 INPUT_LEN=512
-OUTPUT_LEN=32
+OUTPUT_LEN=16
 SIZE_PER_HEAD=128
 HEAD_NUM=96
 MODEL_NAME="gpt3_89B"
@@ -83,11 +83,12 @@ while [ "$1" != "" ]; do
         -d | --num_decoder_layers)  shift
 				    NUM_DECODER_LAYERS=$1
 				    ;;
-	-n | --num_runs)            shift
+	      -n | --num_runs)            shift
 				    NUM_RUNS=$1
 				    ;;
         -h | --help )               shift
 				    usage
+            exit 1
 				    ;;
         * )                         usage
             exit 1

--- a/tools/benchmark_single_node.sh
+++ b/tools/benchmark_single_node.sh
@@ -164,13 +164,13 @@ instance_group [
 parameters {
   key: "candidate_num"
   value: {
-    string_value: "1"
+    string_value: "0"
   }
 }
 parameters {
   key: "probability_threshold"
   value: {
-    string_value: "0.0"
+    string_value: "0.9"
   }
 }
 parameters {
@@ -292,7 +292,7 @@ for PROTOCOL in http; do
 done
 
 # latency will be logged to last line
-tail -n 1 $CLIENT_LOG
+tail -n 2 $CLIENT_LOG
 # kill server
 ps -ef | grep mpirun | grep triton | awk '{print $2}' | while read p; do kill -9 $p ; done
 

--- a/tools/identity_test.py
+++ b/tools/identity_test.py
@@ -201,7 +201,7 @@ if __name__ == '__main__':
         latencies.append((stop_time - start_time).total_seconds()
                          * 1000.0 / request_parallelism)
     if FLAGS.num_runs > 1:
-        print(f"[INFO] execution time var: {s.variance(latencies)}")
+        print(latencies)
         print(f"[INFO] execution time: {s.mean(latencies)} ms")
     else:
         print(f"[INFO] execution time: {latencies[0]} ms")

--- a/tools/identity_test.py
+++ b/tools/identity_test.py
@@ -33,6 +33,7 @@ import re
 import sys
 import requests as httpreq
 from builtins import range
+import statistics as s
 import tritongrpcclient as grpcclient
 import tritonhttpclient as httpclient
 from tritonclientutils import np_to_triton_dtype
@@ -48,6 +49,56 @@ random_start_ids = np.array([[9915, 27221, 59, 77, 383, 1853, 3327, 1462],
                              [9915, 27221, 59, 77, 383, 1853, 3327, 1462],
                              [6601, 4237, 345, 460, 779, 284, 787, 257]], np.uint32)
 
+
+def send_requests(request_parallelism=10):
+    model_name = "fastertransformer"
+    with client_util.InferenceServerClient(FLAGS.url,
+                                           concurrency=request_parallelism,
+                                           verbose=FLAGS.verbose) as client:
+        requests = []
+        results = []
+        for i in range(request_parallelism):
+            input_data = random_start_ids
+            inputs = [
+                client_util.InferInput("INPUT_ID", input_data.shape,
+                                       np_to_triton_dtype(input_data.dtype)),
+                client_util.InferInput("REQUEST_INPUT_LEN", input_len.shape,
+                                       np_to_triton_dtype(input_len.dtype)),
+                client_util.InferInput("REQUEST_OUTPUT_LEN", output_len.shape,
+                                       np_to_triton_dtype(output_len.dtype))
+            ]
+            inputs[0].set_data_from_numpy(input_data)
+            inputs[1].set_data_from_numpy(input_len)
+            inputs[2].set_data_from_numpy(output_len)
+            #requests.append(client.async_infer(model_name, inputs))
+            print("set request")
+            result = client.infer(model_name, inputs)
+            print("get request")
+            results.append(result)
+
+        for i in range(request_parallelism):
+            # Get the result from the initiated asynchronous inference request.
+            # Note the call will block till the server responds.
+            print("wait result return 0000\n")
+            ##results = requests[i].get_result()
+            print("wait result return 1111\n")
+            # print(results[i])
+            print("get results\n")
+
+            output_data = results[i].as_numpy("OUTPUT0")
+            output_data = output_data.reshape([-1, FLAGS.batch_size])
+            np.savetxt("triton_out", output_data, fmt='%u')
+            output_data = output_data.T
+            print("get results as OUTPUT0\n")
+            if output_data is None:
+                print("error: expected 'OUTPUT0'")
+                sys.exit(1)
+            else:
+                print("OUTPUT0 is received")
+                print(output_data.shape)
+                print(output_data)
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('-v',
@@ -61,20 +112,26 @@ if __name__ == '__main__':
                         type=str,
                         required=False,
                         help='Inference server URL.')
-    parser.add_argument(
-        '-i',
-        '--protocol',
-        type=str,
-        required=False,
-        default='http',
-        help='Protocol ("http"/"grpc") used to ' +
-        'communicate with inference service. Default is "http".')
+    parser.add_argument('-i',
+                        '--protocol',
+                        type=str,
+                        required=False,
+                        default='http',
+                        help='Protocol ("http"/"grpc") used to ' +
+                        'communicate with inference service. Default is "http".')
     parser.add_argument('-r',
                         '--random_start_ids',
                         action="store_true",
                         required=False,
                         default=True,
                         help='Enable random start ids')
+    parser.add_argument('-w',
+                        '--warm_up',
+                        action="store_true",
+                        required=False,
+                        default=True,
+                        help='Enable warm_up before benchmark')
+
     parser.add_argument('-b',
                         '--batch_size',
                         type=int,
@@ -96,8 +153,14 @@ if __name__ == '__main__':
                         required=False,
                         help='Specify output length')
 
-    
-    
+    parser.add_argument('-n',
+                        '--num_runs',
+                        type=int,
+                        default=1,
+                        required=False,
+                        help="Spedifty number of runs to get the average latency"
+                        )
+
     FLAGS = parser.parse_args()
     if (FLAGS.protocol != "http") and (FLAGS.protocol != "grpc"):
         print("unexpected protocol \"{}\", expects \"http\" or \"grpc\"".format(
@@ -110,95 +173,35 @@ if __name__ == '__main__':
         FLAGS.url = "localhost:8000" if FLAGS.protocol == "http" else "localhost:8001"
 
     if FLAGS.random_start_ids:
-        random_start_ids = np.random.randint(0, 50255, size=(FLAGS.batch_size, FLAGS.start_len), dtype=np.uint32)
-    input_len = np.array([ [sentence.size] for sentence in random_start_ids ], np.uint32)
+        random_start_ids = np.random.randint(0, 50255, size=(
+            FLAGS.batch_size, FLAGS.start_len), dtype=np.uint32)
+
+    input_len = np.array([[sentence.size]
+                         for sentence in random_start_ids], np.uint32)
     output_len = np.ones_like(input_len).astype(np.uint32) * FLAGS.output_len
 
     # Run async requests to make sure backend handles request batches
     # correctly. We use just HTTP for this since we are not testing the
     # protocol anyway.
 
-    # warmup
-    if FLAGS.protocol == "http":
-        request_parallelism = 10
-        model_name = "fastertransformer"
-        # shape = [8, 8]
-        with client_util.InferenceServerClient(FLAGS.url,
-                                               concurrency=request_parallelism,
-                                               verbose=FLAGS.verbose) as client:
-            requests = []
-            results = []
-            for i in range(request_parallelism):
-                input_data = random_start_ids
-                inputs = [
-                    client_util.InferInput("INPUT_ID", input_data.shape,
-                                           np_to_triton_dtype(input_data.dtype)),
-                    client_util.InferInput("REQUEST_INPUT_LEN", input_len.shape,
-                                           np_to_triton_dtype(input_len.dtype)),
-                    client_util.InferInput("REQUEST_OUTPUT_LEN", output_len.shape,
-                                           np_to_triton_dtype(output_len.dtype))
-                ]
-                inputs[0].set_data_from_numpy(input_data)
-                inputs[1].set_data_from_numpy(input_len)
-                inputs[2].set_data_from_numpy(output_len)
-                result = client.infer(model_name, inputs)
-                results.append(result)
-
-            for i in range(request_parallelism):
-                # Get the result from the initiated asynchronous inference request.
-                # Note the call will block till the server responds.
-                output_data = results[i].as_numpy("OUTPUT0")
-
+    # warm up
+    if FLAGS.protocol == "http" and FLAGS.warm_up:
+        print("[INFO] sending requests to warm up")
+        send_requests(2)
+    import time
+    time.sleep(5)  # TODO: Not sure if this is necessary
     from datetime import datetime
     request_parallelism = 10
-    start_time = datetime.now()
-    if FLAGS.protocol == "http":
-        model_name = "fastertransformer"
-        # shape = [8, 8]
-        with client_util.InferenceServerClient(FLAGS.url,
-                                               concurrency=request_parallelism,
-                                               verbose=FLAGS.verbose) as client:
-            requests = []
-            results = []
-            for i in range(request_parallelism):
-                input_data = random_start_ids
-                inputs = [
-                    client_util.InferInput("INPUT_ID", input_data.shape,
-                                           np_to_triton_dtype(input_data.dtype)),
-                    client_util.InferInput("REQUEST_INPUT_LEN", input_len.shape,
-                                           np_to_triton_dtype(input_len.dtype)),
-                    client_util.InferInput("REQUEST_OUTPUT_LEN", output_len.shape,
-                                           np_to_triton_dtype(output_len.dtype))
-                ]
-                inputs[0].set_data_from_numpy(input_data)
-                inputs[1].set_data_from_numpy(input_len)
-                inputs[2].set_data_from_numpy(output_len)
-                #requests.append(client.async_infer(model_name, inputs))
-                print("set request")
-                result = client.infer(model_name, inputs)
-                print("get request")
-                results.append(result)
-
-            for i in range(request_parallelism):
-                # Get the result from the initiated asynchronous inference request.
-                # Note the call will block till the server responds.
-                print("wait result return 0000\n")
-                ##results = requests[i].get_result()
-                print("wait result return 1111\n")
-                # print(results[i])
-                print("get results\n")
-
-                output_data = results[i].as_numpy("OUTPUT0")
-                output_data = output_data.reshape([-1, FLAGS.batch_size])
-                np.savetxt("triton_out", output_data, fmt='%u')
-                output_data = output_data.T
-                print("get results as OUTPUT0\n")
-                if output_data is None:
-                    print("error: expected 'OUTPUT0'")
-                    sys.exit(1)
-                else:
-                    print("OUTPUT0 is received")
-                    print(output_data.shape)
-                    print(output_data)
-    stop_time = datetime.now()
-    print("[INFO] execution time: {} ms".format((stop_time - start_time).total_seconds() * 1000.0 / request_parallelism))
+    latencies = []
+    for i in range(FLAGS.num_runs):
+        start_time = datetime.now()
+        if FLAGS.protocol == "http":
+            send_requests(request_parallelism)
+        stop_time = datetime.now()
+        latencies.append((stop_time - start_time).total_seconds()
+                         * 1000.0 / request_parallelism)
+    if FLAGS.num_runs > 1:
+        print(f"[INFO] execution time var: {s.variance(latencies)}")
+        print(f"[INFO] execution time: {s.mean(latencies)} ms")
+    else:
+        print(f"[INFO] execution time: {latencies[0]} ms")


### PR DESCRIPTION
* reformat
* add -n param to send requests multiple times and get average latency

```
# batch size = 1, run 10 times and get average
bash $WORKSPACE/fastertransformer_backend/tools/benchmark_single_node.sh -b 1 -n 10 
```