### PR TITLE
Install Go 1.16 with precompiled binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,10 +111,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         python3-protobuf \
         python3-setuptools \
         swig \
-        golang-go \
         nginx \
         protobuf-compiler \
         valgrind
+
+RUN wget https://go.dev/dl/go1.16.4.linux-amd64.tar.gz && \
+	rm -rf /usr/local/go && \
+	tar -C /usr/local -xzf go1.16.4.linux-amd64.tar.gz
+
+ENV PATH=/usr/local/go/bin:$PATH
 
 RUN pip3 install --upgrade wheel setuptools && \
     pip3 install --upgrade numpy pillow future grpcio requests gsutil awscli six boofuzz grpcio-channelz azure-cli


### PR DESCRIPTION
The `apt-get install golang-go` installs Go version 1.13. This fails with this error:

```bash
Step 18/26 : RUN go get github.com/golang/protobuf/protoc-gen-go &&         go get google.golang.org/grpc
 ---> Running in fd6421564474
# golang.org/x/net/http2
/root/go/src/golang.org/x/net/http2/transport.go:417:45: undefined: os.ErrDeadlineExceeded
The command '/bin/sh -c go get github.com/golang/protobuf/protoc-gen-go &&         go get google.golang.org/grpc' returned a non-zero code: 2
```

This can be fixed by using a more updated version of Go, following the instructions from the official Go page https://go.dev/doc/install.