### PR TITLE
docs: fix formating in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Multiple model instances on same GPUs will share the weights, so there will not 
 
 Set `count` here to start multiple model instances. Note `KIND_CPU` is the only choice here as the backend needs to take full control of how to distribute multiple model instances to all the visible GPUs.
 
-```json
+```pbtxt
 instance_group [
   {
     count: 8


### PR DESCRIPTION
Change `Specify Multiple Model Instances`'s example format from `json` to `pbtxt`

Signed-off-by: Thytu <valentin.de-matos@epitech.eu>