### PR TITLE
fix error handling

### DIFF
--- a/src/libfastertransformer.cc
+++ b/src/libfastertransformer.cc
@@ -1433,8 +1433,9 @@ ModelInstanceState::Execute(
   try {
     for (int gid = model_instance_device_id_start_;
       gid < model_instance_device_id_start_ + model_instance_gpu_size_; gid++){
-        if (exception_ptr[gid]) {
-          std::rethrow_exception(exception_ptr[gid]);
+        int instance_local_id = gid - model_instance_device_id_start_;
+        if (exception_ptr[instance_local_id]) {
+          std::rethrow_exception(exception_ptr[instance_local_id]);
         }
     }
   }


### PR DESCRIPTION
https://github.com/triton-inference-server/fastertransformer_backend/commit/fd0e2e1b7790a7402bb7b91437ed34664acfeb54 introduced handling of exceptions from the model instance but this exception handling itself crashes due to wrong index..